### PR TITLE
Requires testit package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ License: GPL-2
 Imports:
     ape,
     coda,
-    deSolve
+    deSolve,
+    testit
 Suggests:
     DDD,
     ggplot2,
@@ -22,7 +23,6 @@ Suggests:
     reshape2,
     rmarkdown,
     TESS,
-    testit,
     testthat,
     TreeSim
 NeedsCompilation: no


### PR DESCRIPTION
Looks like `testit` is a requirement -- `nLTTstat_exact` fails to run without it, probably because of [L203](https://github.com/richelbilderbeek/nLTT/blob/master/R/nLTTDiff.R#L203) and others.